### PR TITLE
Threading issue

### DIFF
--- a/XMLRPCConnection.m
+++ b/XMLRPCConnection.m
@@ -55,7 +55,10 @@ static NSOperationQueue *parsingQueue;
 #endif
         myData = [[NSMutableData alloc] init];
         
-        myConnection = [[NSURLConnection alloc] initWithRequest: [request request] delegate: self];
+        myConnection = [[NSURLConnection alloc] initWithRequest: [request request] delegate: self startImmediately:NO];
+        [myConnection scheduleInRunLoop:[NSRunLoop mainRunLoop]
+                                forMode:NSDefaultRunLoopMode];
+        [myConnection start];
         
 #if ! __has_feature(objc_arc)
         myDelegate = [delegate retain];


### PR DESCRIPTION
Hi Nikolay,

There was a bug in your xmlrpc library causing the delegate methods never to be called because the request was running in a loop that wasn't the main loop.

This pull request should fix that issue.

I hope you're merging soon, I'm using this library as a dependency in a project ;)

Cheers,

Frederic
